### PR TITLE
[#30] Do not use the default secret when deploying the api-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,14 @@ To undeploy, run
 ```sh
 ./undeploy.sh
 ```
+
+### Notes about the JWT secret
+
+The api server uses SECRET_ACCESS_TOKEN env var to get the secret for generating
+jwt tokens. It has a default value in .env for dev purposes.
+
+In production you should override it with your own secret.
+
+The jwt-key-gen.sh is a tool to generate a random key and used in Dockerfile. 
+It makes sure when you build the api server image a new random key is used.
+

--- a/jwt-key-gen.sh
+++ b/jwt-key-gen.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+# generate a new jwt secret
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+


### PR DESCRIPTION
Added a script to generate random secret
Updated Dockerfile to generate a random secret into .env 
Removed unused commands in Dockerfile
Updated README